### PR TITLE
get_arguments() takes only one paramter

### DIFF
--- a/main.py
+++ b/main.py
@@ -353,7 +353,7 @@ class CommandHandler(tornado.web.RequestHandler):
 			writetldirs(self)
 		
 		if op == "deltlfiles":
-			filestodel=self.get_arguments('tlfiles',None)
+			filestodel=self.get_arguments('tlfiles')
 			filespathtodel = []
 			for f in filestodel:
 				filespathtodel.append (os.path.join(timelapsedir, self.get_argument('tlfolder',None),f))


### PR DESCRIPTION
There is no 'default' parameter in get_arguments()
